### PR TITLE
首届996优秀项目大赛邀请函

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![996.icu](https://img.shields.io/badge/link-996.icu-red.svg)](https://996.icu)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+[![top.996](https://img.shields.io/badge/link-top.996-red.svg)](https://github.com/top996/top.996)
 
 以公开信的形式，向中华全国总工会、人资和社保部等劳动相关部门寻求帮助，呼吁相关政府部门采取下列行动：
 


### PR DESCRIPTION
首届996优秀项目大赛，投票截止日期为2019年7月1日，7月10日公布最终比赛结果。 大赛选取了目前github上各个反996热门项目，大赛前三名将获得对应的项目发展支持基金。 一等奖人民币5000元，二等奖人民币3000元，三等奖人民币1000元，四到六名纪念奖人民币300元。
添加徽章加站长微信群就送50元报名红包。
[站长请加微信群](https://github.com/top996/top.996)